### PR TITLE
Dockerfile support for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_IMAGE_TAG=1.17
-FROM golang:${GOLANG_IMAGE_TAG} as build
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_IMAGE_TAG} as build
 COPY GNUmakefile /src/GNUmakefile
 COPY scripts /src/scripts
 RUN cd /src && \
@@ -7,20 +7,19 @@ RUN cd /src && \
     apt install -y zip  && \
     make tools
 
-FROM golang:${GOLANG_IMAGE_TAG} as runner
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_IMAGE_TAG} as runner
 ARG TERRAFORM_VERSION=1.2.4
 ARG TFLINT_AZURERM_VERSION=0.16.0
+ARG BUILDARCH
 ENV TFLINT_PLUGIN_DIR /tflint
 COPY --from=build $GOPATH/bin $GOPATH/bin
 COPY --from=build /usr/local/bin/tflint /bin/tflint
-
 RUN apt update && apt install -y curl zip python3 pip coreutils jq nodejs npm && \
     npm install markdown-table-formatter -g && \
     pip install checkov && \
-    export ARCH=$(uname -m | sed 's/x86_64/amd64/g') && \
-    curl '-#' -fL -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_$ARCH.zip && \
+    curl '-#' -fL -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_$BUILDARCH.zip && \
 	unzip -q -d /bin/ /tmp/terraform.zip && \
-	curl '-#' -fL -o /tmp/tflint-ruleset-azurerm.zip https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v${TFLINT_AZURERM_VERSION}/tflint-ruleset-azurerm_linux_$ARCH.zip && \
+	curl '-#' -fL -o /tmp/tflint-ruleset-azurerm.zip https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v${TFLINT_AZURERM_VERSION}/tflint-ruleset-azurerm_linux_$BUILDARCH.zip && \
 	mkdir -p $TFLINT_PLUGIN_DIR/github.com/terraform-linters/tflint-ruleset-azurerm/$TFLINT_AZURERM_VERSION && \
     unzip -q -d $TFLINT_PLUGIN_DIR/github.com/terraform-linters/tflint-ruleset-azurerm/$TFLINT_AZURERM_VERSION /tmp/tflint-ruleset-azurerm.zip && \
 	rm -f /tmp/terraform.zip && \


### PR DESCRIPTION
These changes are required to build this Dockerfile for platforms like arm64. You can build as follows:

```
docker buildx build --platform=linux/amd64,linux/arm64 -o type=registry,push=true -t docker.io/zioproto/tfmodule-ghrunner .
```

Note that I dropped the `ARCH` variable in favour of the `BUILDARCH` that comes from Docker:
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/